### PR TITLE
Fix hardcoded port 80

### DIFF
--- a/dashboard/app/services/reports.js
+++ b/dashboard/app/services/reports.js
@@ -9,7 +9,7 @@ angular.module('app')
         summaries = [],
         facilities = [],
 
-		configRestEndpoint = "http://" + APP_CONFIG.DATASTORE_REST_HOSTNAME + '.' + $location.host().replace(/^.*?\.(.*)/g,"$1") + '/api';
+		configRestEndpoint = "http://" + APP_CONFIG.DATASTORE_REST_HOSTNAME + '.' + $location.host().replace(/^.*?\.(.*)/g,"$1") + ":" + APP_CONFIG.DATASTORE_REST_PORT + '/api';
 
 
 	factory.getSummaries = function() {

--- a/dashboard/app/services/vehicles.js
+++ b/dashboard/app/services/vehicles.js
@@ -6,7 +6,7 @@ angular.module('app')
 
 	var factory = {},
 		vehicles = [],
-		configRestEndpoint = "http://" + APP_CONFIG.DATASTORE_REST_HOSTNAME + '.' + $location.host().replace(/^.*?\.(.*)/g,"$1") + '/api/vehicles';
+		configRestEndpoint = "http://" + APP_CONFIG.DATASTORE_REST_HOSTNAME + '.' + $location.host().replace(/^.*?\.(.*)/g,"$1") + ":" + APP_CONFIG.DATASTORE_REST_PORT+ '/api/vehicles';
 
 
 	factory.getVehicles = function() {

--- a/dashboard/config.js
+++ b/dashboard/config.js
@@ -1,8 +1,8 @@
 var config =
 {
     // hostname/port/name/password for Kapua broker
-    BROKER_WEBSOCKET_HOSTNAME: process.env.BROKER_WS_NAME + '-' + process.env.OPENSHIFT_BUILD_NAMESPACE,
-    BROKER_WEBSOCKET_PORT: process.env.BROKER_WEBSOCKET_PORT || 80,
+    BROKER_WEBSOCKET_HOSTNAME: process.env.EXTERNAL_IPADDRESS_HEAD,
+    BROKER_WEBSOCKET_PORT: 37151,//61614
     BROKER_USERNAME: process.env.BROKER_USERNAME || "demo_username",
     BROKER_PASSWORD: process.env.BROKER_PASSWORD || "demo_password",
 
@@ -10,8 +10,8 @@ var config =
     ES_PORT: process.env.ES_PORT || 80,
 
     // hostname/port for DG proxy (no username/password required for demo)
-    DATASTORE_REST_HOSTNAME: process.env.DATASTORE_PROXY_SERVICE + '-' + process.env.OPENSHIFT_BUILD_NAMESPACE,
-    DATASTORE_REST_PORT: process.env.DATASTORE_REST_PORT || 80,
+    DATASTORE_REST_HOSTNAME: process.env.EXTERNAL_IPADDRESS_HEAD,
+    DATASTORE_REST_PORT: 37173,//8080
 
     // Google API Key (can be blank, resulting in throttling for high usage)
     GOOGLE_MAPS_API_KEY: process.env.GOOGLE_MAPS_API_KEY || "",


### PR DESCRIPTION
URL does not reference overriding port used in config.js. It assumes default port 80 will always be used.